### PR TITLE
Add plugin functionality

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,9 @@ def parse_output(lines):
 ### Config file
 In ~/.tdsr.cfg you add to the plugins and commands section to modify the shortcut and terminal command that has been run
 
-Required: The plugin section maps to a letter you press with alt to trigger the plugin.
+Required: [plugins] The plugin section maps to a letter you press with alt to trigger the plugin.
 
-Optional: The command section is a string of  the command you ran previous to triggering the plugin (this minimizes processing time)
+Optional: [commands] The command section is a regex of the command you ran previous to triggering the plugin (this minimizes processing time)
 
 Optional: A regex to indicate the start of your prompt line in your terminal
 
@@ -102,9 +102,14 @@ To specify a command of `echo "hi"` (which makes parsing slightly more efficient
 ```
 my_plugin = echo "hi"
 ```
-Use dots for sub folders, like the plugin config
+Use dots for sub folders, like the plugin config. You can use a regular expression to make it more flexible, e.g. to
+specify a command of `echo "hi"` or `echo "bye"`
 
-The default prompt is match anything, if you use zsh you can use the following regular expression:
+```
+my_plugin = echo "(hi|bye)"
+```
+
+The default prompt is match anything, if you use zsh you can use the following regular expression under [speech]:
 
 ```
 prompt = ^➜\s{2}.+✗?

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,62 @@ character code = name
 ```
 Because of how the config system works, it's best to do this with one TDSR open, then exit and re-launch to see the changes.
 
+## Plugins
+Custom key binds and handlers can be added via the plugins and commands section of the config files
+and a python module in the plugins directory that exports the following method signature:
+
+```python
+# Name: parse_output
+# Parameters: an array of strings (the lines from the terminal)
+# Returns: an array of strings (the things to speak)
+def parse_output(lines):
+    return ["a list of things to say"]
+```
+
+### Config file
+In ~/.tdsr.cfg you add to the plugins and commands section to modify the shortcut and terminal command that has been run
+
+Required: The plugin section maps to a letter you press with alt to trigger the plugin.
+
+Optional: The command section is a string of  the command you ran previous to triggering the plugin (this minimizes processing time)
+
+Optional: A regex to indicate the start of your prompt line in your terminal
+
+#### Example
+
+To add a shortcut for alt d to trigger a plugin called my_plugin add the following under [plugins]
+
+```
+my_plugin = d
+```
+If you have sub folders, separate them with a dot e.g. for plugins/me/my_plugin
+
+```
+me.my_plugin = d
+```
+
+To specify a command of `echo "hi"` (which makes parsing slightly more efficient) add the following under [commands]
+```
+my_plugin = echo "hi"
+```
+Use dots for sub folders, like the plugin config
+
+The default prompt is match anything, if you use zsh you can use the following regular expression:
+
+```
+prompt = ^➜\s{2}.+✗?
+```
+
+#### Errors
+
+If you hear "error loading plugin" followed by an error, you can launch tdsr in debug mode
+
+```commandline
+~/tdsr --debug
+```
+
+And search the logs for "Error loading plugin" to see more details
+
 ## License
 Copyright (C) 2016, 2017  Tyler Spivey
 

--- a/tdsr
+++ b/tdsr
@@ -52,6 +52,7 @@ class State:
 		self.config['speech'] = {'process_symbols': 'false', 'key_echo': True, 'cursor_tracking': True,
 		"line_pause": True}
 		self.config['symbols'] = {}
+		self.config['plugins'] = {}
 		self.symbols_Re = None
 		self.copy_x = None
 		self.copy_y = None

--- a/tdsr
+++ b/tdsr
@@ -459,14 +459,19 @@ def handle_plugin(plugin_name):
 	except Exception as e:
 		logger.error(e)
 		say(f"Error loading plugin {e.args}")
+
+	prompt_matcher = re.compile(fr"{state.config.get('speech', 'prompt', fallback='.*')}")
+	command = state.config.get('commands', plugin_name, fallback=None)
+	check_command = command is not None
+	if command:
+		command_matcher = re.compile(command)
+
 	def handle():
 		lines = []
-		prompt_matcher = re.compile(fr"{state.config.get('speech', 'prompt', fallback='.*')}")
-		command = state.config.get('commands', plugin_name, fallback=f'{plugin_name} ')
 		for i in reversed(range(len(screen.buffer))):
 			line = "".join(screen.buffer[i][x].data for x in range(screen.columns)).strip()
 			lines.append(line)
-			if prompt_matcher.match(line) and command in line:
+			if prompt_matcher.search(line) and check_command and command_matcher.search(line):
 				break
 		try:
 			lines_to_read = mod.parse_output(lines)

--- a/tdsr
+++ b/tdsr
@@ -2,6 +2,7 @@
 #tdsr, a terminal screen reader
 #Copyright (C) 2016, 2017  Tyler Spivey
 #See the license in COPYING.txt
+import importlib
 import sys
 import os
 import select
@@ -81,6 +82,10 @@ class KeyHandler:
 		self.fd = fd
 		self.last_key = None
 		self.last_key_time = 0.0
+
+	def add(self, key, handler):
+		if key not in self.keymap:
+			self.keymap[key] = handler
 
 	def process(self, data):
 		key_time = time.time()
@@ -356,6 +361,10 @@ def main():
 	decoder = codecs.getincrementaldecoder('utf-8')(errors='replace')
 	default_key_handler = KeyHandler(keymap, fd)
 	state.key_handlers.append(default_key_handler)
+	plugins = dict(state.config.items('plugins'))
+	for plugin, shortcut in plugins.items():
+		default_key_handler.add(f'\x1b{shortcut}'.encode(), handle_plugin(plugin))
+
 	termios.tcsetattr(fd, termios.TCSADRAIN, old)
 	resize_terminal(fd)
 	signal_pipe = os.pipe()
@@ -443,6 +452,31 @@ def handle_delete():
 	x = screen.cursor.x
 	say_character(screen.buffer[screen.cursor.y][screen.cursor.x].data)
 	return KeyHandler.PASSTHROUGH
+
+def handle_plugin(plugin_name):
+	try:
+		mod = importlib.import_module(f"plugins.{plugin_name}")
+	except Exception as e:
+		logger.error(e)
+		say(f"Error loading plugin {e.args}")
+	def handle():
+		lines = []
+		prompt_matcher = re.compile(fr"{state.config.get('speech', 'prompt', fallback='.*')}")
+		command = state.config.get('commands', plugin_name, fallback=f'{plugin_name} ')
+		for i in reversed(range(len(screen.buffer))):
+			line = "".join(screen.buffer[i][x].data for x in range(screen.columns)).strip()
+			lines.append(line)
+			if prompt_matcher.match(line) and command in line:
+				break
+		try:
+			lines_to_read = mod.parse_output(lines)
+			for line in lines_to_read:
+				say(line)
+		except Exception as e:
+			logger.error(e)
+			say(f"Error loading plugin {e.args}")
+
+	return handle
 
 def sayline(y):
 	line = "".join(screen.buffer[y][x].data for x in range(screen.columns)).strip()

--- a/tdsr.cfg.dist
+++ b/tdsr.cfg.dist
@@ -1,5 +1,10 @@
 [speech]
 process_symbols = False
+prompt = .*
+
+[commands]
+
+[plugins]
 
 [symbols]
 32 = space


### PR DESCRIPTION
With this you can now add python code to run on custom keyboard shortcuts to parse the terminal output and speak it in a more useful way.
There is a small efficiency boost by configuring the command you ran previous to pressing the shortcut and stop parsing the terminal output when found. This isn't necessary but reduces how much output a plugin gets passed which makes it faster and slightly safer (as it should stop it receiving any sensitive output).

An example use case is the pytest output, instead of all the irrelevant stuff from pytest you could now pull out the test count, the error message and the line of code that triggered it e.g. "1 failed, 5 passed, AttributeError: 'NoneType' object has no attribute 'group', code is results = parse_output(lines)"

Implements https://github.com/tspivey/tdsr/issues/33

I've pushed a [plugin repo](https://github.com/hbk619/tdsr-plugins) to show how you could share plugins. Cloning that repo into plugins/ and then configuring with the right folder/file names works with this branch :smile: 