### PR TITLE
Repeat symbols condensing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ Once in the config menu, you can use:
 * p - toggle symbol processing.
 * d - set cursor delay (in MS). The default is 20.
 * l - Toggle pausing at newlines.
+* s - Toggle repeated symbols
 * Enter - exit, saving the configuration.
 
 ## Symbols
@@ -63,6 +64,13 @@ The format is:
 character code = name
 ```
 Because of how the config system works, it's best to do this with one TDSR open, then exit and re-launch to see the changes.
+
+## Repeating symbols
+Symbols you would like condensed down to "42 =" instead of "= = = =" you can specify under the speech section
+
+```
+repeated_symbols_values = -_=! 
+```
 
 ## License
 Copyright (C) 2016, 2017  Tyler Spivey

--- a/tdsr
+++ b/tdsr
@@ -453,15 +453,20 @@ def sayline(y):
 	if line == u'':
 		line = u'blank'
 
-	results = matcher.finditer(line)
+	new_line = replace_duplicate_characters_with_count(line)
 
+	say(new_line)
+
+
+def replace_duplicate_characters_with_count(line):
+	results = matcher.finditer(line)
 	new_line = line
 	for r in results:
 		match = r.group()
 		if len(match) > 1:
 			new_line = new_line.replace(match, f"{len(match)} {r.groups()[0]}", 1)
+	return new_line
 
-	say(new_line)
 
 def prevline():
 	state.revy -= 1
@@ -618,7 +623,8 @@ def sb():
 	if data == u'':
 		return
 	if not state.tempsilence:
-		say(data)
+		new_line = replace_duplicate_characters_with_count(data)
+		say(new_line)
 
 def say(data, force_process_symbols=False):
 	data = data.strip()

--- a/tdsr
+++ b/tdsr
@@ -51,7 +51,7 @@ class State:
 		self.key_handlers = []
 		self.config = configparser.ConfigParser()
 		self.config['speech'] = {'process_symbols': 'false', 'key_echo': True, 'cursor_tracking': True,
-		"line_pause": True}
+		"line_pause": True, 'repeated_symbols': 'false', 'repeated_symbols_values': '-=!#'}
 		self.config['symbols'] = {}
 		self.symbols_Re = None
 		self.copy_x = None
@@ -117,6 +117,7 @@ class ConfigHandler(KeyHandler):
 			b'e': self.set_echo,
 			b'c': self.set_cursor_tracking,
 			b'l': self.set_line_pause,
+			b's': self.set_repeated_symbols,
 		}
 		super().__init__(self.keymap)
 
@@ -193,6 +194,13 @@ class ConfigHandler(KeyHandler):
 		state.config['speech']['line_pause'] = str(current)
 		state.save_config()
 		say("line pause on" if current else "line pause off")
+
+	def set_repeated_symbols(self):
+		current = state.config.getboolean('speech', 'repeated_symbols', fallback=False)
+		current = not current
+		state.config['speech']['repeated_symbols'] = str(current)
+		state.save_config()
+		say("repeated symbols on" if current else "repeated symbols off")
 
 	def set_delay(self):
 		say("Cursor delay")
@@ -446,7 +454,6 @@ def handle_delete():
 	say_character(screen.buffer[screen.cursor.y][screen.cursor.x].data)
 	return KeyHandler.PASSTHROUGH
 
-matcher = re.compile(r'([-=!#])\1*')
 
 def sayline(y):
 	line = "".join(screen.buffer[y][x].data for x in range(screen.columns)).strip()
@@ -459,12 +466,16 @@ def sayline(y):
 
 
 def replace_duplicate_characters_with_count(line):
-	results = matcher.finditer(line)
+	symbols = state.config.get('speech', 'repeated_symbols_values', fallback='-=!#')
+	matcher = re.compile(fr'([{symbols}])\1*')
 	new_line = line
-	for r in results:
-		match = r.group()
-		if len(match) > 1:
-			new_line = new_line.replace(match, f"{len(match)} {r.groups()[0]}", 1)
+	if state.config.getboolean('speech', 'repeated_symbols'):
+		results = matcher.finditer(line)
+		for r in results:
+			match = r.group()
+			if len(match) > 1:
+				new_line = new_line.replace(match, f"{len(match)} {r.groups()[0]}", 1)
+
 	return new_line
 
 

--- a/tdsr
+++ b/tdsr
@@ -23,6 +23,8 @@ import logging
 import platform
 import signal
 import copy
+import re
+
 logger = logging.getLogger("tdsr")
 logger.addHandler(logging.NullHandler())
 
@@ -444,11 +446,22 @@ def handle_delete():
 	say_character(screen.buffer[screen.cursor.y][screen.cursor.x].data)
 	return KeyHandler.PASSTHROUGH
 
+matcher = re.compile(r'([-=!#])\1*')
+
 def sayline(y):
 	line = "".join(screen.buffer[y][x].data for x in range(screen.columns)).strip()
 	if line == u'':
 		line = u'blank'
-	say(line)
+
+	results = matcher.finditer(line)
+
+	new_line = line
+	for r in results:
+		match = r.group()
+		if len(match) > 1:
+			new_line = new_line.replace(match, f"{len(match)} {r.groups()[0]}", 1)
+
+	say(new_line)
 
 def prevline():
 	state.revy -= 1


### PR DESCRIPTION
Rather than saying "equals equals equals equals equals", bundle everything up and say "five equals"
This is useful for things such as pytest which has output like
============================================================= 44 failed in 0.27s ==============================

You can disable or enable the behaviour with the keyboard while running and specify your own list of symbols to condense in the config file

Fixes #34 