### PR TITLE
support python 3.14 by using importlib.resources.abc.Traversable

### DIFF
--- a/tdsr/tdsr.py
+++ b/tdsr/tdsr.py
@@ -11,6 +11,7 @@ import struct
 import termios
 import codecs
 import pyte
+from importlib.resources.abc import Traversable
 from importlib.resources import as_file, files
 from wcwidth import wcwidth
 from io import StringIO, SEEK_END


### PR DESCRIPTION
The importlib.abc.Traverseable call was depricated in 3.12.
