### PR TITLE
Announce capital letters when reviewing by character

### DIFF
--- a/tdsr/backend/mac.py
+++ b/tdsr/backend/mac.py
@@ -74,9 +74,11 @@ def gotLine(observer, line):
 def handle_line(line):
 	global rate, volume, voice_idx
 	line = line.decode('utf-8', 'replace')
-	if line[0] == u"s" or line[0] == "l":
+	if line[0] == u"s" or line[0] == "l" or line[0] == "L":
 		ln = line[1:].replace('[[', ' ')
 		ln = ln.replace(u'\u23ce', ' ')
+		if line[0] == "L":
+			ln = "cap " + ln
 		# macOS 26 doesn't process text in <>, even though we're not telling it to speak SSML.
 		ln = html.escape(ln, False)
 		u = AVSpeechUtterance.alloc().initWithString_(ln)

--- a/tdsr/backend/speechdispatcher.py
+++ b/tdsr/backend/speechdispatcher.py
@@ -20,9 +20,9 @@ def main():
 		if line[0] == u"s":
 			synth.speak(line[1:])
 		elif line[0] == u"l":
-			# TODO capitals.  Do pitchrise here, or just
-			# let it be Speech Dispatcher's problem?
 			synth.char(line[1:])
+		elif line[0] == u"L":
+			synth.speak("cap " + line[1:])
 		elif line[0] == u"x":
 			synth.cancel()
 		elif line[0] == u"r":

--- a/tdsr/tdsr.py
+++ b/tdsr/tdsr.py
@@ -739,6 +739,8 @@ def say_character(ch):
 	key = str(ord(ch))
 	if key in state.config['symbols']:
 		synth.send('s%s\n' % state.config['symbols'][key])
+	elif ch.isupper():
+		synth.send('L%s\n' % ch)
 	else:
 		synth.send('l%s\n' % ch)
 


### PR DESCRIPTION
Fixes #56.

When reviewing text by character (arrow keys, or Alt+`,`/Alt+`.`), tdsr didn't distinguish capital letters from lowercase — important context when reviewing e.g. code.

`say_character()` now sends a distinct `L` command (instead of `l`) for uppercase letters. Both backends speak "cap " before the letter in that case:
- `backend/mac.py`
- `backend/speechdispatcher.py` (replaces the existing TODO about capitals)